### PR TITLE
Initializing on module required

### DIFF
--- a/lib/env_config_manager.js
+++ b/lib/env_config_manager.js
@@ -6,7 +6,7 @@ var
 
 require('colors');
 
-nconf.init = init;
+nconf.init = init();
 
 module.exports = nconf;
 


### PR DESCRIPTION
I know this wouldn't allow someone to add their own configs but I would prefer it to be initialized immediately. Possibly add configs into a default file. and then the init could read from that?
